### PR TITLE
Add Meson build definitions.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('docopt.cpp', 'cpp',
+        version: '0.6.3',
+        license: 'Boost',
+        meson_version: '>=0.55.0',
+        default_options: 'cpp_std=c++11')
+
+doclib = library('docopt', 'docopt.cpp')
+executable('docopt_example', 'examples/naval_fate.cpp', link_with: doclib)
+docopt_dep = declare_dependency(include_directories: '.',
+    link_with: doclib)
+meson.override_dependency('docopt', docopt_dep)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = docopt.cpp-0.6.3
+
+source_url = https://github.com/docopt/docopt.cpp/archive/v0.6.3.tar.gz
+source_filename = v0.6.3.tar.gz
+source_hash = 28af5a0c482c6d508d22b14d588a3b0bd9ff97135f99c2814a5aa3cbff1d6632


### PR DESCRIPTION
I added an override declaration as well. It only works for versions >= 0.55 but since this is a wholly new project, it won't break any existing code.